### PR TITLE
Less recursive LuaErrors + JavaLib

### DIFF
--- a/allium/build.gradle.kts
+++ b/allium/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	modImplementation(include("cc.tweaked", "cobalt", cobalt))
 	modImplementation(include("me.basiqueevangelist","enhanced-reflection", enhancedReflections))
 	modImplementation(include("net.fabricmc", "tiny-mappings-parser", tinyParser))
+
 }
 
 java {

--- a/allium/build.gradle.kts
+++ b/allium/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
 	modImplementation(include("cc.tweaked", "cobalt", cobalt))
 	modImplementation(include("me.basiqueevangelist","enhanced-reflection", enhancedReflections))
 	modImplementation(include("net.fabricmc", "tiny-mappings-parser", tinyParser))
-
 }
 
 java {

--- a/allium/src/main/java/dev/hugeblank/allium/loader/ClassBuilder.java
+++ b/allium/src/main/java/dev/hugeblank/allium/loader/ClassBuilder.java
@@ -1,0 +1,224 @@
+package dev.hugeblank.allium.loader;
+
+import dev.hugeblank.allium.loader.type.StaticBinder;
+import dev.hugeblank.allium.loader.type.annotation.LuaStateArg;
+import dev.hugeblank.allium.loader.type.annotation.LuaWrapped;
+import dev.hugeblank.allium.loader.type.coercion.TypeCoercions;
+import dev.hugeblank.allium.loader.type.property.PropertyResolver;
+import dev.hugeblank.allium.util.ClassFieldBuilder;
+import dev.hugeblank.allium.util.AsmUtil;
+import me.basiqueevangelist.enhancedreflection.api.EClass;
+import me.basiqueevangelist.enhancedreflection.api.EConstructor;
+import me.basiqueevangelist.enhancedreflection.api.EMethod;
+import me.basiqueevangelist.enhancedreflection.api.EParameter;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.squiddev.cobalt.*;
+import org.squiddev.cobalt.function.LuaFunction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.objectweb.asm.Opcodes.*;
+
+@LuaWrapped
+public class ClassBuilder {
+    protected final EClass<?> superClass;
+    protected final String className;
+    protected final LuaState state;
+    protected final ClassWriter c = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    private final List<EMethod> methods = new ArrayList<>();
+    private final ClassFieldBuilder fields;
+
+    @LuaWrapped
+    public ClassBuilder(EClass<?> superClass, List<EClass<?>> interfaces, LuaState state) {
+        this.state = state;
+        this.className = AsmUtil.getUniqueClassName();
+        this.fields = new ClassFieldBuilder(className, c);
+
+        this.c.visit(
+                V17,
+                ACC_PUBLIC,
+                className,
+                null,
+                superClass.name().replace('.', '/'),
+                interfaces.stream().map(x -> x.name().replace('.', '/')).toArray(String[]::new)
+        );
+
+        for (EConstructor<?> superCtor : superClass.constructors()) {
+            if (!superCtor.isPublic()) continue;
+
+            var desc = Type.getConstructorDescriptor(superCtor.raw());
+            var m = c.visitMethod(superCtor.modifiers(), "<init>", desc, null, null);
+            m.visitCode();
+            var args = Type.getArgumentTypes(desc);
+
+            m.visitVarInsn(ALOAD, 0);
+
+            int argIndex = 1;
+
+            for (Type arg : args) {
+                m.visitVarInsn(arg.getOpcode(ILOAD), argIndex);
+
+                argIndex += arg.getSize();
+            }
+
+            m.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(superClass.raw()), "<init>", desc, false);
+            m.visitInsn(RETURN);
+
+            m.visitMaxs(0, 0);
+            m.visitEnd();
+        }
+
+        this.superClass = superClass;
+        this.methods.addAll(this.superClass.methods());
+        for (var inrf : interfaces) {
+            this.methods.addAll(inrf.methods());
+        }
+    }
+
+    @LuaWrapped
+    public void overrideMethod(@LuaStateArg LuaState state, String methodName, EClass<?>[] parameters, LuaFunction func) throws LuaError {
+        var methods = new ArrayList<EMethod>();
+
+        PropertyResolver.collectMethods(state, this.superClass, this.methods, methodName, false, methods::add);
+
+        for (var method : methods) {
+            var methParams = method.parameters();
+
+            if (methParams.size() == parameters.length) {
+                boolean match = true;
+                for (int i = 0; i < parameters.length; i++) {
+                    if (!methParams.get(i).parameterType().upperBound().raw().equals(parameters[i].raw())) {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match) {
+                    writeMethod(
+                        method.name(),
+                        methParams.stream().map(WrappedType::fromParameter).toArray(WrappedType[]::new),
+                        new WrappedType(method.rawReturnType(), method.returnType().upperBound()),
+                        method.modifiers() & ~ACC_ABSTRACT,
+                        func
+                    );
+
+                    return;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException("Couldn't find method " + methodName + " in parent class " + superClass.name() + "!");
+    }
+
+    @LuaWrapped
+    public void createMethod(String methodName, EClass<?>[] params, EClass<?> returnClass, boolean isStatic, LuaFunction func) {
+        writeMethod(
+            methodName,
+            Arrays.stream(params).map(x -> new WrappedType(x, x)).toArray(WrappedType[]::new),
+            returnClass == null ? null : new WrappedType(returnClass, returnClass),
+            isStatic ? (ACC_PUBLIC | ACC_STATIC) : ACC_PUBLIC,
+            func
+        );
+
+    }
+
+    private void writeMethod(String methodName, WrappedType[] params, WrappedType returnClass, int access, LuaFunction func) {
+        var paramsType = Arrays.stream(params).map(x -> x.raw).map(EClass::raw).map(Type::getType).toArray(Type[]::new);
+        var returnType = returnClass == null ? Type.VOID_TYPE : Type.getType(returnClass.raw.raw());
+        var isStatic = (access & ACC_STATIC) != 0;
+
+        var desc = Type.getMethodDescriptor(returnType, paramsType);
+        var m = c.visitMethod(access, methodName, desc, null, null);
+        int varPrefix = Type.getArgumentsAndReturnSizes(desc) >> 2;
+        int thisVarOffset = isStatic ? 0 : 1;
+
+        m.visitCode();
+
+        if (isStatic) varPrefix -= 1;
+
+        m.visitLdcInsn(params.length + thisVarOffset);
+        m.visitTypeInsn(ANEWARRAY, Type.getInternalName(LuaValue.class));
+        m.visitVarInsn(ASTORE, varPrefix);
+
+        if (!isStatic) {
+            m.visitVarInsn(ALOAD, varPrefix);
+            m.visitLdcInsn(0);
+            m.visitVarInsn(ALOAD, 0);
+            fields.storeAndGetComplex(m, EClass::fromJava, EClass.class, className);
+            m.visitMethodInsn(INVOKESTATIC, Type.getInternalName(TypeCoercions.class), "toLuaValue", "(Ljava/lang/Object;Lme/basiqueevangelist/enhancedreflection/api/EClass;)Lorg/squiddev/cobalt/LuaValue;", false);
+            m.visitInsn(AASTORE);
+        }
+
+        int argIndex = thisVarOffset;
+        var args = Type.getArgumentTypes(desc);
+        for (int i = 0; i < args.length; i++) {
+            m.visitVarInsn(ALOAD, varPrefix);
+            m.visitLdcInsn(i + thisVarOffset);
+            m.visitVarInsn(args[i].getOpcode(ILOAD), argIndex);
+
+            if (args[i].getSort() != Type.OBJECT || args[i].getSort() != Type.ARRAY) {
+                AsmUtil.wrapPrimitive(m, args[i]);
+            }
+
+            fields.storeAndGet(m, params[i].real.wrapPrimitive(), EClass.class);
+            m.visitMethodInsn(INVOKESTATIC, Type.getInternalName(TypeCoercions.class), "toLuaValue", "(Ljava/lang/Object;Lme/basiqueevangelist/enhancedreflection/api/EClass;)Lorg/squiddev/cobalt/LuaValue;", false);
+            m.visitInsn(AASTORE);
+
+            argIndex += args[i].getSize();
+        }
+
+        var isVoid = returnClass == null || returnType.getSort() == Type.VOID;
+
+        fields.storeAndGet(m, state, LuaState.class);
+        if (!isVoid) m.visitInsn(DUP);
+        fields.storeAndGet(m, func, LuaFunction.class);
+        m.visitInsn(SWAP);
+        m.visitVarInsn(ALOAD, varPrefix);
+        m.visitMethodInsn(INVOKESTATIC, Type.getInternalName(ValueFactory.class), "varargsOf", "([Lorg/squiddev/cobalt/LuaValue;)Lorg/squiddev/cobalt/Varargs;", false);
+        m.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(LuaFunction.class), "invoke", "(Lorg/squiddev/cobalt/LuaState;Lorg/squiddev/cobalt/Varargs;)Lorg/squiddev/cobalt/Varargs;", false);
+
+        if (!isVoid) {
+            m.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(Varargs.class), "first", "()Lorg/squiddev/cobalt/LuaValue;", false);
+            fields.storeAndGet(m, returnClass.real.wrapPrimitive(), EClass.class);
+            m.visitMethodInsn(INVOKESTATIC, Type.getInternalName(TypeCoercions.class), "toJava", "(Lorg/squiddev/cobalt/LuaState;Lorg/squiddev/cobalt/LuaValue;Lme/basiqueevangelist/enhancedreflection/api/EClass;)Ljava/lang/Object;", false);
+            m.visitTypeInsn(CHECKCAST, Type.getInternalName(returnClass.real.wrapPrimitive().raw()));
+
+            if (returnType.getSort() != Type.ARRAY && returnType.getSort() != Type.OBJECT) {
+                AsmUtil.unwrapPrimitive(m, returnType);
+            }
+        }
+
+        m.visitInsn(returnType.getOpcode(IRETURN));
+
+        m.visitMaxs(0, 0);
+        m.visitEnd();
+    }
+
+    public byte[] getByteArray() {
+        return c.toByteArray();
+    }
+
+    @LuaWrapped
+    public LuaValue build() throws LuaError {
+        byte[] classBytes = c.toByteArray();
+
+        Class<?> klass = AsmUtil.defineClass(className, classBytes);
+
+        fields.apply(klass);
+
+        return StaticBinder.bindClass(EClass.fromJava(klass));
+    }
+
+    public String getName() {
+        return this.className;
+    }
+
+    private record WrappedType(EClass<?> raw, EClass<?> real) {
+        public static WrappedType fromParameter(EParameter param) {
+            return new WrappedType(param.rawParameterType(), param.parameterType().lowerBound());
+        }
+    }
+}

--- a/allium/src/main/java/dev/hugeblank/allium/loader/EnvironmentManager.java
+++ b/allium/src/main/java/dev/hugeblank/allium/loader/EnvironmentManager.java
@@ -37,6 +37,7 @@ public class EnvironmentManager {
             LibFunction.setGlobalLibrary(state, globals, "script",
                     TypeCoercions.toLuaValue(script, EClass.fromJava(Script.class))
             );
+            loadLibrary(script, state, globals, new JavaLib());
         } catch (LuaError error) {
             script.getLogger().error("Error loading library:", error);
         }

--- a/allium/src/main/java/dev/hugeblank/allium/loader/JavaLib.java
+++ b/allium/src/main/java/dev/hugeblank/allium/loader/JavaLib.java
@@ -1,0 +1,80 @@
+package dev.hugeblank.allium.loader;
+
+import dev.hugeblank.allium.api.WrappedLuaLibrary;
+import dev.hugeblank.allium.loader.type.*;
+import dev.hugeblank.allium.loader.type.annotation.LuaStateArg;
+import dev.hugeblank.allium.loader.type.annotation.LuaWrapped;
+import dev.hugeblank.allium.loader.type.annotation.OptionalArg;
+import dev.hugeblank.allium.loader.type.coercion.TypeCoercions;
+import dev.hugeblank.allium.util.JavaHelpers;
+import me.basiqueevangelist.enhancedreflection.api.EClass;
+import org.squiddev.cobalt.*;
+
+import java.util.List;
+
+@LuaWrapped(name = "java")
+public class JavaLib implements WrappedLuaLibrary {
+
+    @LuaWrapped
+    public static LuaValue cast(@LuaStateArg LuaState state, LuaUserdata object, EClass<?> klass) throws LuaError {
+        try {
+            return TypeCoercions.toLuaValue(TypeCoercions.toJava(state, object, klass), klass);
+        } catch (InvalidArgumentException e) {
+            throw new LuaError(e);
+        }
+    }
+
+    @LuaWrapped
+    public static boolean instanceOf(@LuaStateArg LuaState state, LuaUserdata object, EClass<?> klass) {
+        try {
+            Object obj = TypeCoercions.toJava(state, object, Object.class);
+            return klass.isAssignableFrom(obj.getClass());
+        } catch (LuaError | InvalidArgumentException e) {
+            return false;
+        }
+    }
+
+    @LuaWrapped
+    public static boolean exists(@LuaStateArg LuaState state, String string, @OptionalArg Class<?>[] value) {
+        try {
+            var parts = string.split("#");
+            var clazz = getRawClass(state, parts[0]);
+
+            if (parts.length != 2) {
+                return true;
+            }
+
+            if (value != null) {
+                return clazz.method(parts[1], value) != null;
+            } else {
+                for (var method : clazz.methods()) {
+                    if (method.name().equals(parts[1])) {
+                        return true;
+                    }
+                }
+
+                return clazz.field(parts[1]) != null;
+            }
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @LuaWrapped
+    public static ClassBuilder extendClass(@LuaStateArg LuaState state, EClass<?> superclass, @OptionalArg List<EClass<?>> interfaces) {
+        if (interfaces == null) interfaces = List.of();
+        return new ClassBuilder(superclass, interfaces, state);
+    }
+
+    @LuaWrapped
+    public static EClass<?> getRawClass(@LuaStateArg LuaState state, String className) throws LuaError {
+        return JavaHelpers.getRawClass(state, className);
+
+    }
+
+    @LuaWrapped
+    public void exception(Throwable error) throws Throwable {
+        throw error;
+    }
+}
+

--- a/allium/src/main/java/dev/hugeblank/allium/loader/type/RethrowException.java
+++ b/allium/src/main/java/dev/hugeblank/allium/loader/type/RethrowException.java
@@ -1,0 +1,13 @@
+package dev.hugeblank.allium.loader.type;
+
+public final class RethrowException extends RuntimeException {
+    public RethrowException(Throwable throwable) {
+        super(null, null, false, false); // Disable stack trace + suppression
+        rethrow(throwable);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void rethrow(Throwable throwable) throws T {
+        throw (T) throwable;
+    }
+}

--- a/allium/src/main/java/dev/hugeblank/allium/loader/type/UDFFunctions.java
+++ b/allium/src/main/java/dev/hugeblank/allium/loader/type/UDFFunctions.java
@@ -82,7 +82,7 @@ public final class UDFFunctions<T> extends VarArgFunction {
                             if (e.getTargetException() instanceof LuaError err)
                                 throw err;
 
-                            throw new LuaError(e.getTargetException());
+                            throw new RethrowException(e.getTargetException());
                         }
                     }
                 } catch (InvalidArgumentException e) {


### PR DESCRIPTION
When a Java exception was thrown within a Lua environment, it used to be wrapped in a LuaError every time.
With this intermediate Exception class, this doesn't occur.