### PR TITLE
feat(bouquet): Add WORLD_RENDER client event for 3D overlays

### DIFF
--- a/bouquet/examples/block_inspector/main.lua
+++ b/bouquet/examples/block_inspector/main.lua
@@ -1,0 +1,129 @@
+-- Block Inspector
+-- Displays info about the block you're looking at near the crosshair,
+-- and renders a green 3D outline on the targeted block in the world.
+
+local events = require("bouquet").events
+
+if allium.environment() ~= "client" then return end
+
+local Component = require("net.minecraft.network.chat.Component")
+local BuiltInRegistries = require("net.minecraft.core.registries.BuiltInRegistries")
+local ShapeRenderer = require("net.minecraft.client.renderer.ShapeRenderer")
+local RenderTypes = require("net.minecraft.client.renderer.rendertype.RenderTypes")
+local CollisionContext = require("net.minecraft.world.phys.shapes.CollisionContext")
+
+-- Shared state between tick and render
+local blockName = nil
+local blockId = nil
+local blockPosText = nil
+local stateProps = nil
+
+-- World render state
+local targetPos = nil
+local targetShape = nil
+
+-- Gather block info each tick
+events.common.playerTick:register(script, function(player)
+    local level = player:level()
+    if not level:isClientSide() then return end
+
+    local hitResult = player:pick(5, 0, false)
+    local pos = hitResult:getBlockPos()
+    local state = level:getBlockState(pos)
+    local block = state:getBlock()
+
+    local identifier = BuiltInRegistries.BLOCK:getKey(block)
+    local namespace = identifier:getNamespace()
+    local path = identifier:getPath()
+
+    if namespace == "minecraft" and path == "air" then
+        blockName = nil
+        blockId = nil
+        blockPosText = nil
+        stateProps = nil
+        targetPos = nil
+        targetShape = nil
+        return
+    end
+
+    blockName = Component.translatable("block." .. namespace .. "." .. path)
+    blockId = namespace .. ":" .. path
+    blockPosText = pos:getX() .. ", " .. pos:getY() .. ", " .. pos:getZ()
+
+    -- Store position and shape for 3D rendering
+    targetPos = pos
+    targetShape = state:getShape(level, pos, CollisionContext.empty())
+
+    -- Collect block state properties
+    local props = state:getProperties()
+    local propLines = {}
+    local iter = props:iterator()
+    while iter:hasNext() do
+        local prop = iter:next()
+        local value = state:getValue(prop)
+        propLines[#propLines + 1] = prop:getName() .. "=" .. tostring(value)
+    end
+    if #propLines > 0 then
+        stateProps = table.concat(propLines, ", ")
+    else
+        stateProps = nil
+    end
+end)
+
+-- Render 3D block outline in the world
+events.client.worldRender:register(script, function(client, poseStack, camera, bufferSource, deltaTracker)
+    if not targetPos or not targetShape then return end
+
+    local camPos = camera:position()
+    local rx = targetPos:getX() - camPos:x()
+    local ry = targetPos:getY() - camPos:y()
+    local rz = targetPos:getZ() - camPos:z()
+
+    local consumer = bufferSource:getBuffer(RenderTypes.lines())
+    -- Green outline (ARGB: 0xFF00FF00), line width 3.0
+    ShapeRenderer.renderShape(poseStack, consumer, targetShape, rx, ry, rz, 0xFF00FF00, 3.0)
+end)
+
+-- Render HUD overlay near crosshair
+events.client.guiRenderTail:register(script, function(client, context, deltaTracker, gui)
+    if not blockName then return end
+
+    local font = gui:getFont()
+    local cx = context:guiWidth() / 2
+    local cy = context:guiHeight() / 2
+
+    -- Position text just below and to the right of the crosshair
+    local x = cx + 12
+    local y = cy + 12
+    local lineHeight = 11
+
+    -- Build lines to display
+    local lines = {}
+    lines[#lines + 1] = { text = blockName, color = 0xffffffff }
+    lines[#lines + 1] = { text = blockId, color = 0xff999999 }
+    lines[#lines + 1] = { text = blockPosText, color = 0xffaaaaaa }
+    if stateProps then
+        lines[#lines + 1] = { text = stateProps, color = 0xff77bbff }
+    end
+
+    -- Calculate background box dimensions
+    local maxWidth = 0
+    for i = 1, #lines do
+        local w = font:width(lines[i].text)
+        if w > maxWidth then maxWidth = w end
+    end
+
+    local padding = 4
+    local boxX = x - padding
+    local boxY = y - padding
+    local boxW = x + maxWidth + padding
+    local boxH = y + (#lines * lineHeight) + padding - 2
+
+    -- Draw semi-transparent background (ARGB)
+    context:fill(boxX, boxY, boxW, boxH, 0xAA000000)
+
+    -- Draw each line
+    for i = 1, #lines do
+        context:drawString(font, lines[i].text, x, y + (i - 1) * lineHeight, lines[i].color)
+    end
+end)

--- a/bouquet/examples/block_inspector/manifest.json
+++ b/bouquet/examples/block_inspector/manifest.json
@@ -1,0 +1,8 @@
+{
+  "id": "block_inspector",
+  "version": "1.0.0",
+  "name": "Block Inspector",
+  "entrypoints": {
+    "dynamic": "main.lua"
+  }
+}

--- a/bouquet/src/client/java/dev/hugeblank/bouquet/api/event/ClientEventHandlers.java
+++ b/bouquet/src/client/java/dev/hugeblank/bouquet/api/event/ClientEventHandlers.java
@@ -1,9 +1,12 @@
 package dev.hugeblank.bouquet.api.event;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.MultiBufferSource;
 
 // For all events that use classes that the server doesn't have.
 // Make sure to provide a dummy method with no parameters for it.
@@ -13,5 +16,9 @@ public class ClientEventHandlers {
 
     public interface GuiRender {
         void onGuiRender(Minecraft client, GuiGraphics context,  DeltaTracker deltaTracker, Gui hud);
+    }
+
+    public interface WorldRender {
+        void onWorldRender(Minecraft client, PoseStack poseStack, Camera camera, MultiBufferSource.BufferSource bufferSource, DeltaTracker deltaTracker);
     }
 }

--- a/bouquet/src/client/java/dev/hugeblank/bouquet/api/event/ClientEvents.java
+++ b/bouquet/src/client/java/dev/hugeblank/bouquet/api/event/ClientEvents.java
@@ -7,4 +7,6 @@ public class ClientEvents {
     public static final SimpleEventType<ClientEventHandlers.GuiRender> GUI_RENDER_HEAD = new SimpleEventType<>();
     // The end of the client render cycle (renders above everything in the gui)
     public static final SimpleEventType<ClientEventHandlers.GuiRender> GUI_RENDER_TAIL = new SimpleEventType<>();
+    // Fires after the world has been rendered, allowing 3D overlays to be drawn in world-space
+    public static final SimpleEventType<ClientEventHandlers.WorldRender> WORLD_RENDER = new SimpleEventType<>();
 }

--- a/bouquet/src/client/java/dev/hugeblank/bouquet/mixin/client/renderer/LevelRendererMixin.java
+++ b/bouquet/src/client/java/dev/hugeblank/bouquet/mixin/client/renderer/LevelRendererMixin.java
@@ -1,0 +1,62 @@
+package dev.hugeblank.bouquet.mixin.client.renderer;
+
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.hugeblank.bouquet.api.event.ClientEvents;
+import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderBuffers;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fStack;
+import org.joml.Vector4f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LevelRenderer.class)
+public class LevelRendererMixin {
+    @Shadow
+    @Final
+    private Minecraft minecraft;
+
+    @Shadow
+    @Final
+    private RenderBuffers renderBuffers;
+
+    @Inject(method = "renderLevel", at = @At("TAIL"))
+    private void onWorldRender(
+            GraphicsResourceAllocator resourceAllocator,
+            DeltaTracker deltaTracker,
+            boolean renderOutline,
+            Camera camera,
+            Matrix4f modelViewMatrix,
+            Matrix4f projectionMatrix,
+            Matrix4f projectionMatrixForCulling,
+            GpuBufferSlice terrainFog,
+            Vector4f fogColor,
+            boolean shouldRenderSky,
+            CallbackInfo ci
+    ) {
+        Matrix4fStack modelViewStack = RenderSystem.getModelViewStack();
+        modelViewStack.pushMatrix();
+        modelViewStack.mul(modelViewMatrix);
+
+        PoseStack poseStack = new PoseStack();
+        MultiBufferSource.BufferSource bufferSource = this.renderBuffers.bufferSource();
+
+        ClientEvents.WORLD_RENDER.invoker().onWorldRender(
+                this.minecraft, poseStack, camera, bufferSource, deltaTracker
+        );
+
+        bufferSource.endBatch();
+        modelViewStack.popMatrix();
+    }
+}

--- a/bouquet/src/client/resources/bouquet.client.mixins.json
+++ b/bouquet/src/client/resources/bouquet.client.mixins.json
@@ -1,12 +1,13 @@
 {
-	"required": true,
-	"package": "dev.hugeblank.bouquet.mixin",
-	"compatibilityLevel": "JAVA_21",
-	"client": [
-      "client.gui.hud.GuiMixin",
-		"server.integrated.IntegratedServerMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	}
+  "required": true,
+  "package": "dev.hugeblank.bouquet.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "client": [
+    "client.gui.hud.GuiMixin",
+    "client.renderer.LevelRendererMixin",
+    "server.integrated.IntegratedServerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }

--- a/bouquet/src/main/resources/bouquet/api/events.lua
+++ b/bouquet/src/main/resources/bouquet/api/events.lua
@@ -25,6 +25,7 @@ if allium.environment() == "client" then
     out.client = {
         guiRenderHead = ClientEvents.GUI_RENDER_HEAD,
         guiRenderTail = ClientEvents.GUI_RENDER_TAIL,
+        worldRender = ClientEvents.WORLD_RENDER,
     }
 end
 


### PR DESCRIPTION
## Summary

Adds a `WORLD_RENDER` client event to Bouquet, enabling Lua scripts to draw 3D geometry in world-space. This opens up use cases like block highlights, waypoint markers, and debug visualizations — all from Lua.

## Changes

### New event: `WORLD_RENDER`

**Handler signature:**
```java
void onWorldRender(Minecraft client, PoseStack poseStack, Camera camera,
                   MultiBufferSource.BufferSource bufferSource, DeltaTracker deltaTracker);
```

**Lua usage:**
```lua
events.client.worldRender:register(script, function(client, poseStack, camera, bufferSource, deltaTracker)
    -- Draw 3D geometry here
end)
```

The event fires at the tail of `LevelRenderer.renderLevel()`. The mixin restores the model-view matrix, creates a fresh `PoseStack` and `BufferSource`, fires the event, flushes the buffer, then cleans up. This follows the same pattern used internally by `addLateDebugPass`.

### Files modified

| File | Change |
|------|--------|
| `ClientEventHandlers.java` | Added `WorldRender` handler interface |
| `ClientEvents.java` | Added `WORLD_RENDER` SimpleEventType |
| `LevelRendererMixin.java` | **New** — injects at TAIL of `renderLevel()` |
| `bouquet.client.mixins.json` | Registered new mixin |
| `events.lua` | Exposed `worldRender` to Lua |

### New example: `block_inspector`

Demonstrates the new event with a practical use case:
- **3D green wireframe outline** on the block the player is looking at (using `ShapeRenderer.renderShape` with `RenderTypes.lines()`)
- **HUD info panel** near the crosshair showing block name, registry ID, coordinates, and block state properties

## Parameters provided to Lua scripts

| Parameter | Type | Purpose |
|-----------|------|---------|
| `client` | `Minecraft` | Access to player, level, hit result |
| `poseStack` | `PoseStack` | Transform stack for positioning geometry |
| `camera` | `Camera` | Camera position via `camera:position()` for world-to-screen translation |
| `bufferSource` | `MultiBufferSource.BufferSource` | Get vertex consumers via `bufferSource:getBuffer(renderType)` |
| `deltaTracker` | `DeltaTracker` | Partial tick for smooth animation |

## Testing

1. `.\gradlew.bat :bouquet:build` — compiles cleanly
2. `.\gradlew.bat :bouquet:runClient` — launch client
3. Load a singleplayer world
4. Look at any block — green wireframe outline appears on the block, info panel displays near crosshair
5. Look at air — overlay and panel disappear
